### PR TITLE
feat: separate put-object-retention and head-object as main operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uses the AWS Go SDK.
 
 Build for regular amd64 arches (linux):
 ```bash
-GOOS=linux GOARCH=amd64 go build .
+GOOS=linux GOARCH=amd64 go build -o s3bench .
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ uses the AWS Go SDK.
 ## Requirements
 * Go
 
+## Build
+
+Build for regular amd64 arches (linux):
+```bash
+GOOS=linux GOARCH=amd64 go build .
+```
+
 ## Installation
 Run the following command to build the binary.
 


### PR DESCRIPTION
- Add put-object-retention as separate operation
- head-object as separate operation
- Clean up output
- Remove list-objects-after-writes